### PR TITLE
Fix FileActivator writing

### DIFF
--- a/src/Activators/FileActivator.php
+++ b/src/Activators/FileActivator.php
@@ -29,6 +29,7 @@ class FileActivator implements ActivatorInterface
     {
         $statuses = $this->getStatuses();
         $statuses[$extension] = $status;
+        File::ensureDirectoryExists(dirname($this->jsonFile));
         return File::put($this->jsonFile, json_encode($statuses, JSON_PRETTY_PRINT)) !== false;
     }
 }


### PR DESCRIPTION
## Summary
- ensure json directory exists before writing status

## Testing
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68455fce12788333b86f22f2c6285d05