### PR TITLE
Add support for switchable extension types

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The package uses a configuration file (`config/extensions.php`) to define settin
 - **Extensions Paths**: Directories where extensions are stored.
 - **Protected Extensions**: Extensions that cannot be disabled or deleted.
 - **Load Order**: Specify the order in which extensions are loaded.
+- **Switchable Types**: Types where only one extension of the type can be active;
+  enabling one will automatically disable the others.
 
 ---
 

--- a/config/extensions.php
+++ b/config/extensions.php
@@ -24,6 +24,18 @@ return [
     ],
 
     /*
+    |----------------------------------------------------------------------
+    | Switchable Types
+    |----------------------------------------------------------------------
+    | List extension types where only one extension of a given type can be
+    | active at a time. Enabling an extension of one of these types will
+    | automatically disable the others of the same type.
+    */
+    'switch_types' => [
+        // 'theme',
+    ],
+
+    /*
     |--------------------------------------------------------------------------
     | Extensions Paths
     |--------------------------------------------------------------------------

--- a/src/Services/ExtensionsService.php
+++ b/src/Services/ExtensionsService.php
@@ -243,6 +243,24 @@ class ExtensionsService
      */
     public function enable(string $name): string
     {
+        $ext = $this->get($name);
+
+        if ($ext) {
+            $type        = $ext->getType();
+            $switchTypes = config('extensions.switch_types', []);
+
+            if ($type && in_array($type, $switchTypes, true)) {
+                foreach ($this->all() as $other) {
+                    if ($other->getName() === $name) {
+                        continue;
+                    }
+                    if ($other->getType() === $type && ! $other->isProtected()) {
+                        $this->activator->setStatus($other->getName(), false);
+                    }
+                }
+            }
+        }
+
         $ok = $this->activator->setStatus($name, true);
         $this->invalidateCache();
         return $ok ? "Extension enabled." : "Enable failed.";


### PR DESCRIPTION
## Summary
- allow marking extension types as switchable so only one can be active
- update service enable logic to auto-disable other extensions of same type
- document switchable types configuration

## Testing
- `php -l src/Services/ExtensionsService.php`
- `php -l config/extensions.php`
- `composer validate --no-check-all --ansi`


------
https://chatgpt.com/codex/tasks/task_e_688efa8ce3048333a513f681cb798411