### PR TITLE
Add extension lifecycle event hooks

### DIFF
--- a/stubs/Extension/Extension.php.stub
+++ b/stubs/Extension/Extension.php.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{namespace}}\{{name}};
+
+class Extension
+{
+    public static function onInstall(): void
+    {
+        // Called after the extension is installed
+    }
+
+    public static function onEnable(): void
+    {
+        // Called after the extension is enabled
+    }
+
+    public static function onDisable(): void
+    {
+        // Called after the extension is disabled
+    }
+
+    public static function onDelete(): void
+    {
+        // Called before the extension is deleted
+    }
+}


### PR DESCRIPTION
## Summary
- trigger optional lifecycle hooks (onInstall/onEnable/onDisable/onDelete) if extension defines an `Extension` class
- scaffold extension event class stub for new extensions

## Testing
- `php -l src/Services/ExtensionsService.php`
- `composer validate --strict`


------
https://chatgpt.com/codex/tasks/task_e_688efebc0a548333a624e3682578d271