### PR TITLE
Allow disabling protected switch-type extensions

### DIFF
--- a/src/Entities/Extension.php
+++ b/src/Entities/Extension.php
@@ -47,7 +47,7 @@ class Extension
 
     public function isActive(): bool
     {
-        return $this->active || $this->isProtected();
+        return $this->active;
     }
 
     public function isProtected(): bool

--- a/src/Services/Concerns/ExtensionHelpers.php
+++ b/src/Services/Concerns/ExtensionHelpers.php
@@ -32,6 +32,25 @@ trait ExtensionHelpers
     }
 
     /**
+     * Determine if an extension can be disabled.
+     *
+     * Protected extensions can only be disabled when their type is listed
+     * in the "switch_types" configuration.
+     */
+    protected function canDisable(string $name): bool
+    {
+        if (! $this->isProtected($name)) {
+            return true;
+        }
+
+        $ext        = $this->get($name);
+        $switch     = config('extensions.switch_types', []);
+        $type       = $ext?->getType();
+
+        return $type && in_array($type, $switch, true);
+    }
+
+    /**
      * Clear the internal cache so next call to all() rescans statuses.
      */
     protected function invalidateCache(): void

--- a/src/Services/Concerns/ManagesExtensions.php
+++ b/src/Services/Concerns/ManagesExtensions.php
@@ -55,7 +55,7 @@ trait ManagesExtensions
                     if ($other->getName() === $name) {
                         continue;
                     }
-                    if ($other->getType() === $type && ! $other->isProtected()) {
+                    if ($other->getType() === $type && $this->canDisable($other->getName())) {
                         $this->activator->setStatus($other->getName(), false);
                     }
                 }
@@ -75,7 +75,7 @@ trait ManagesExtensions
      */
     public function disable(string $name): string
     {
-        if ($this->isProtected($name)) {
+        if (! $this->canDisable($name)) {
             return "Extension '{$name}' is protected.";
         }
         $ext = $this->get($name);


### PR DESCRIPTION
## Summary
- allow disabling protected extensions whose type is listed in `switch_types`
- ensure other switch-type extensions are disabled even if protected
- respect stored status for protected switch-type extensions when listing

## Testing
- `composer validate --no-check-all --no-interaction`
- `php -l src/Services/Concerns/ExtensionHelpers.php`
- `php -l src/Services/Concerns/ManagesExtensions.php`
- `php -l src/Services/Concerns/QueriesExtensions.php`
- `php -l src/Entities/Extension.php`


------
https://chatgpt.com/codex/tasks/task_e_688f2f7bcde4833386dd6d267ea5d5f2