### PR TITLE
Refactor extension commands to remove duplication and align style

### DIFF
--- a/src/Commands/BaseExtensionCommand.php
+++ b/src/Commands/BaseExtensionCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Gigabait93\Extensions\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+abstract class BaseExtensionCommand extends Command
+{
+    protected Filesystem $files;
+
+    protected array $bases;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->files = new Filesystem;
+        $this->bases = config('extensions.paths', []);
+    }
+
+    protected function availableStubs(string $stubRoot): array
+    {
+        $groups = [];
+
+        foreach ($this->files->allFiles($stubRoot) as $file) {
+            $rel = Str::after($file->getPathname(), $stubRoot . DIRECTORY_SEPARATOR);
+            $rel = str_replace('\\', '/', $rel);
+            $group = Str::before($rel, '/');
+            $group = Str::before($group, '.');
+            $groups[] = Str::lower($group);
+        }
+
+        return array_values(array_unique($groups));
+    }
+
+    protected function resolveBasePath(bool $interactive, ?string $basePath): ?string
+    {
+        if (empty($this->bases)) {
+            $this->error("Please configure at least one entry in config('extensions.paths')");
+
+            return null;
+        }
+
+        $paths = array_values($this->bases);
+
+        if ($basePath && in_array($basePath, $paths, true)) {
+            return $basePath;
+        }
+
+        if ($interactive) {
+            return $this->choice('Select base path for the extension', $paths);
+        }
+
+        $this->error('Base path is required');
+
+        return null;
+    }
+}

--- a/src/Commands/DeleteCommand.php
+++ b/src/Commands/DeleteCommand.php
@@ -2,18 +2,19 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Illuminate\Console\Command;
 
 class DeleteCommand extends Command
 {
-    protected $signature   = 'extension:delete {extension}';
+    protected $signature = 'extension:delete {extension}';
     protected $description = 'Remove the extension';
 
     public function handle(): void
     {
-        $name   = $this->argument('extension');
+        $name = $this->argument('extension');
         $result = Extensions::delete($name);
+
         $this->info($result);
     }
 }

--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -2,18 +2,19 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Illuminate\Console\Command;
 
 class DisableCommand extends Command
 {
-    protected $signature   = 'extension:disable {extension}';
+    protected $signature = 'extension:disable {extension}';
     protected $description = 'Disable the extension';
 
     public function handle(): void
     {
-        $name   = $this->argument('extension');
+        $name = $this->argument('extension');
         $result = Extensions::disable($name);
+
         $this->info($result);
     }
 }

--- a/src/Commands/DiscoverCommand.php
+++ b/src/Commands/DiscoverCommand.php
@@ -2,12 +2,12 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Illuminate\Console\Command;
 
 class DiscoverCommand extends Command
 {
-    protected $signature   = 'extension:discover';
+    protected $signature = 'extension:discover';
     protected $description = 'Scan extensions catalog and synchronize them with repository';
 
     public function handle(): void

--- a/src/Commands/EnableCommand.php
+++ b/src/Commands/EnableCommand.php
@@ -2,18 +2,19 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Illuminate\Console\Command;
 
 class EnableCommand extends Command
 {
-    protected $signature   = 'extension:enable {extension}';
+    protected $signature = 'extension:enable {extension}';
     protected $description = 'Enable the extension';
 
     public function handle(): void
     {
-        $name   = $this->argument('extension');
+        $name = $this->argument('extension');
         $result = Extensions::enable($name);
+
         $this->info($result);
     }
 }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -2,17 +2,17 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Illuminate\Console\Command;
 
 class InstallCommand extends Command
 {
-    protected $signature   = 'extension:install {extension} {--force}';
+    protected $signature = 'extension:install {extension} {--force}';
     protected $description = 'Set up a new extension (migrate + seed)';
 
     public function handle(): void
     {
-        $name  = $this->argument('extension');
+        $name = $this->argument('extension');
         $force = $this->option('force');
 
         $result = Extensions::install($name, $force);

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -2,21 +2,21 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Illuminate\Console\Command;
 
 class ListCommand extends Command
 {
-    protected $signature   = 'extension:list';
+    protected $signature = 'extension:list';
     protected $description = 'Outputs a list of all extensions';
 
     public function handle(): void
     {
         $rows = Extensions::all()->map(function ($ext) {
             return [
-                'Name'   => $ext->getName(),
+                'Name' => $ext->getName(),
                 'Status' => $ext->isActive() ? 'active' : 'inactive',
-                'Type'   => $ext->getType(),
+                'Type' => $ext->getType(),
             ];
         })->toArray();
 

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -2,12 +2,12 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Illuminate\Console\Command;
 
 class MigrateCommand extends Command
 {
-    protected $signature   = 'extension:migrate
+    protected $signature = 'extension:migrate
                             {name? : Extension name (default - all)}
                             {--force : Force the operation without confirmation}';
     protected $description = 'Run migrations and seeders for one or all extensions';
@@ -15,16 +15,17 @@ class MigrateCommand extends Command
     public function handle(): void
     {
         $force = $this->option('force');
-        $name  = $this->argument('name');
+        $name = $this->argument('name');
 
         $list = Extensions::all();
 
         if ($name) {
-            $list = $list->filter(fn($e) => $e->getName() === $name);
+            $list = $list->filter(fn ($e) => $e->getName() === $name);
         }
 
         if ($list->isEmpty()) {
             $this->warn('No extensions to process.');
+
             return;
         }
 

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -4,45 +4,22 @@ namespace Gigabait93\Extensions\Commands;
 
 use Gigabait93\Extensions\Actions\AddStubsAction;
 use Gigabait93\Extensions\Actions\GenerateStubsAction;
-use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
-class StubCommand extends Command
+class StubCommand extends BaseExtensionCommand
 {
     protected $signature = 'extension:stub {name?} {path?} {--stub=* : Stub groups to generate} {--interactive : Ask for missing values}';
     protected $description = 'Generate additional stubs for an existing extension';
 
-    protected Filesystem $files;
-    protected array $bases;
-
-    public function __construct()
-    {
-        parent::__construct();
-        $this->files = new Filesystem;
-        $this->bases = config('extensions.paths', []);
-    }
-
     public function handle(): void
     {
-        if (empty($this->bases)) {
-            $this->error("Please configure at least one entry in config('extensions.paths')");
-            return;
-        }
-
         $interactive = $this->option('interactive');
-        $paths = array_values($this->bases);
-        $basePath = $this->argument('path');
-        if ($basePath && in_array($basePath, $paths, true)) {
-            // ok
-        } elseif ($interactive) {
-            $basePath = $this->choice('Select base path for the extension', $paths);
-        } else {
-            $this->error('Base path is required');
+        $basePath = $this->resolveBasePath($interactive, $this->argument('path'));
+        if (! $basePath) {
             return;
         }
 
-        $extensions = array_map(fn($p) => basename($p), $this->files->directories($basePath));
+        $extensions = array_map(fn ($p) => basename($p), $this->files->directories($basePath));
 
         $name = $this->argument('name');
         if ($name && in_array($name, $extensions, true)) {
@@ -73,26 +50,15 @@ class StubCommand extends Command
         $generator = new GenerateStubsAction($this->files, $stubRoot);
         $action = new AddStubsAction($this->files, $generator);
         $type = basename($basePath);
+
         try {
             $action->execute($name, $basePath, $type, $stubs);
         } catch (\RuntimeException $e) {
             $this->error($e->getMessage());
+
             return;
         }
 
         $this->info('Stubs generated successfully');
-    }
-
-    protected function availableStubs(string $stubRoot): array
-    {
-        $groups = [];
-        foreach ($this->files->allFiles($stubRoot) as $file) {
-            $rel = Str::after($file->getPathname(), $stubRoot . DIRECTORY_SEPARATOR);
-            $rel = str_replace('\\', '/', $rel);
-            $group = Str::before($rel, '/');
-            $group = Str::before($group, '.');
-            $groups[] = Str::lower($group);
-        }
-        return array_values(array_unique($groups));
     }
 }


### PR DESCRIPTION
## Summary
- add `BaseExtensionCommand` with shared filesystem, stub resolution, and base path helpers
- refactor make and stub commands to use the base command
- clean up code style for all console commands

## Testing
- `php -l src/Commands/BaseExtensionCommand.php src/Commands/MakeCommand.php src/Commands/StubCommand.php src/Commands/DeleteCommand.php src/Commands/DiscoverCommand.php src/Commands/DisableCommand.php src/Commands/EnableCommand.php src/Commands/InstallCommand.php src/Commands/ListCommand.php src/Commands/MigrateCommand.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_6894a5c633488333b41664eb0116ebca