### PR TITLE
Improve interactive stub selection and defaults

### DIFF
--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -7,6 +7,7 @@ use Gigabait93\Extensions\Actions\GenerateStubsAction;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use function Laravel\Prompts\{multiselect, select};
 
 class StubCommand extends Command
 {
@@ -32,11 +33,10 @@ class StubCommand extends Command
 
         $paths = array_values($this->bases);
         $basePath = $this->argument('path');
-        if ($basePath && in_array($basePath, $paths, true)) {
-            // ok
-        } elseif ($this->input->isInteractive()) {
-            $basePath = $this->choice(trans('extensions::commands.select_base_path'), $paths);
-        } else {
+        if (! ($basePath && in_array($basePath, $paths, true))) {
+            $basePath = select(trans('extensions::commands.select_base_path'), $paths, $paths[0] ?? null);
+        }
+        if (! $basePath) {
             $this->error(trans('extensions::commands.base_path_required'));
             return;
         }
@@ -44,15 +44,14 @@ class StubCommand extends Command
         $extensions = array_map(fn($p) => basename($p), $this->files->directories($basePath));
 
         $name = $this->argument('name');
-        if ($name && in_array($name, $extensions, true)) {
-            // ok
-        } elseif ($this->input->isInteractive()) {
+        if (! ($name && in_array($name, $extensions, true))) {
             if (empty($extensions)) {
                 $this->error(trans('extensions::commands.no_extensions_found_in_path'));
                 return;
             }
-            $name = $this->choice(trans('extensions::commands.select_extension'), $extensions);
-        } else {
+            $name = select(trans('extensions::commands.select_extension'), $extensions);
+        }
+        if (! $name) {
             $this->error(trans('extensions::commands.extension_name_required'));
             return;
         }
@@ -62,22 +61,17 @@ class StubCommand extends Command
         $available = $this->availableStubs($stubRoot);
         $stubs = $this->option('stub');
         if (empty($stubs)) {
-            if ($this->input->isInteractive()) {
-                $optionAll = trans('extensions::commands.option_all');
-                $choices   = array_merge([$optionAll], $available);
-                $stubs     = $this->choice(trans('extensions::commands.select_stubs'), $choices, null, null, true);
-                if (in_array($optionAll, $stubs, true)) {
-                    $stubs = $available;
-                }
-            } else {
-                $stubs = config('extensions.stubs.default', $available);
+            $optionAll = trans('extensions::commands.option_all');
+            $choices = array_merge([$optionAll], $available);
+            $default = array_values(array_diff(config('extensions.stubs.default') ?: $available, ['extension', 'providers']));
+            $stubs = multiselect(trans('extensions::commands.select_stubs'), $choices, $default);
+            if (in_array($optionAll, $stubs, true)) {
+                $stubs = $available;
             }
         }
 
         $stubs = array_map('strtolower', $stubs);
-        if (!in_array('extension', $stubs, true)) {
-            $stubs[] = 'extension';
-        }
+        $stubs = array_values(array_unique(array_merge($stubs, ['extension', 'providers'])));
 
         $generator = new GenerateStubsAction($this->files, $stubRoot);
         $action = new AddStubsAction($this->files, $generator);
@@ -102,6 +96,7 @@ class StubCommand extends Command
             $group = Str::before($group, '.');
             $groups[] = Str::lower($group);
         }
-        return array_values(array_unique($groups));
+        $groups = array_values(array_unique($groups));
+        return array_values(array_diff($groups, ['extension', 'providers']));
     }
 }


### PR DESCRIPTION
## Summary
- Enable Laravel Prompts for interactive extension generation and stub addition
- Hide `extension` and `providers` stubs from choices while including them automatically

## Testing
- `php -l src/Commands/MakeCommand.php`
- `php -l src/Commands/StubCommand.php`
- `composer install` *(failed: curl error 56 while downloading packages)*
- `composer test` *(command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6894ab33e7188333ae59599d6bb57414