### PR TITLE
Refactor console commands to use Laravel Prompts and share logic

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Gigabait93\Extensions\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+abstract class AbstractCommand extends Command
+{
+    protected Filesystem $files;
+    protected array $bases;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->files = new Filesystem;
+        $this->bases = config('extensions.paths', []);
+    }
+}

--- a/src/Commands/Concerns/HandlesStubs.php
+++ b/src/Commands/Concerns/HandlesStubs.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Gigabait93\Extensions\Commands\Concerns;
+
+use Illuminate\Support\Str;
+use function Laravel\Prompts\{multiselect, select};
+
+trait HandlesStubs
+{
+    protected function selectBasePath(?string $path): ?string
+    {
+        if (empty($this->bases)) {
+            $this->error(trans('extensions::commands.paths_required'));
+            return null;
+        }
+
+        $paths = array_values($this->bases);
+        if (! ($path && in_array($path, $paths, true))) {
+            $path = select(trans('extensions::commands.select_base_path'), $paths, $paths[0] ?? null);
+        }
+
+        if (! $path) {
+            $this->error(trans('extensions::commands.base_path_required'));
+            return null;
+        }
+
+        return $path;
+    }
+
+    protected function availableStubs(string $stubRoot): array
+    {
+        $groups = [];
+        foreach ($this->files->allFiles($stubRoot) as $file) {
+            $rel = Str::after($file->getPathname(), $stubRoot . DIRECTORY_SEPARATOR);
+            $rel = str_replace('\\', '/', $rel);
+            $group = Str::before($rel, '/');
+            $group = Str::before($group, '.');
+            $groups[] = Str::lower($group);
+        }
+        $groups = array_values(array_unique($groups));
+        return array_values(array_diff($groups, ['extension', 'providers']));
+    }
+
+    protected function resolveStubs(array $available): array
+    {
+        $stubs = $this->option('stub');
+        if (empty($stubs)) {
+            $optionAll = trans('extensions::commands.option_all');
+            $choices = array_merge([$optionAll], $available);
+            $default = array_values(array_diff(config('extensions.stubs.default') ?: $available, ['extension', 'providers']));
+            $stubs = multiselect(trans('extensions::commands.select_stubs'), $choices, $default);
+            if (in_array($optionAll, $stubs, true)) {
+                $stubs = $available;
+            }
+        }
+
+        $stubs = array_map('strtolower', $stubs);
+        return array_values(array_unique(array_merge($stubs, ['extension', 'providers'])));
+    }
+}

--- a/src/Commands/Concerns/InteractsWithExtensions.php
+++ b/src/Commands/Concerns/InteractsWithExtensions.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Gigabait93\Extensions\Commands\Concerns;
+
+use Gigabait93\Extensions\Facades\Extensions;
+use function Laravel\Prompts\select;
+
+trait InteractsWithExtensions
+{
+    protected function promptExtension(string $promptKey): ?string
+    {
+        $name = $this->argument('extension');
+        if ($name) {
+            return $name;
+        }
+
+        if (! $this->input->isInteractive()) {
+            $this->error(trans('extensions::commands.extension_name_required'));
+            return null;
+        }
+
+        $list = Extensions::all()->map(fn($e) => $e->getName())->toArray();
+        if (empty($list)) {
+            $this->error(trans('extensions::commands.no_extensions_to_process'));
+            return null;
+        }
+
+        return select(trans($promptKey), $list);
+    }
+}

--- a/src/Commands/DeleteCommand.php
+++ b/src/Commands/DeleteCommand.php
@@ -2,25 +2,22 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Gigabait93\Extensions\Commands\Concerns\InteractsWithExtensions;
+use function Laravel\Prompts\select;
 
-class DeleteCommand extends Command
+class DeleteCommand extends AbstractCommand
 {
+    use InteractsWithExtensions;
+
     protected $signature   = 'extension:delete {extension?}';
     protected $description = 'Remove the extension';
 
     public function handle(): void
     {
-        $name   = $this->argument('extension');
+        $name = $this->promptExtension('extensions::commands.select_extension_delete');
         if (! $name) {
-            $list = Extensions::all()->map(fn($e) => $e->getName())->toArray();
-            if ($this->input->isInteractive()) {
-                $name = $this->choice(trans('extensions::commands.select_extension_delete'), $list);
-            } else {
-                $this->error(trans('extensions::commands.extension_name_required'));
-                return;
-            }
+            return;
         }
         $result = Extensions::delete($name);
         $this->info($result);

--- a/src/Commands/DisableCommand.php
+++ b/src/Commands/DisableCommand.php
@@ -2,25 +2,22 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Gigabait93\Extensions\Commands\Concerns\InteractsWithExtensions;
+use function Laravel\Prompts\select;
 
-class DisableCommand extends Command
+class DisableCommand extends AbstractCommand
 {
+    use InteractsWithExtensions;
+
     protected $signature   = 'extension:disable {extension?}';
     protected $description = 'Disable the extension';
 
     public function handle(): void
     {
-        $name   = $this->argument('extension');
+        $name = $this->promptExtension('extensions::commands.select_extension_disable');
         if (! $name) {
-            $list = Extensions::all()->map(fn($e) => $e->getName())->toArray();
-            if ($this->input->isInteractive()) {
-                $name = $this->choice(trans('extensions::commands.select_extension_disable'), $list);
-            } else {
-                $this->error(trans('extensions::commands.extension_name_required'));
-                return;
-            }
+            return;
         }
         $result = Extensions::disable($name);
         $this->info($result);

--- a/src/Commands/DiscoverCommand.php
+++ b/src/Commands/DiscoverCommand.php
@@ -2,10 +2,9 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
 
-class DiscoverCommand extends Command
+class DiscoverCommand extends AbstractCommand
 {
     protected $signature   = 'extension:discover';
     protected $description = 'Scan extensions catalog and synchronize them with repository';

--- a/src/Commands/EnableCommand.php
+++ b/src/Commands/EnableCommand.php
@@ -2,25 +2,22 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Gigabait93\Extensions\Commands\Concerns\InteractsWithExtensions;
+use function Laravel\Prompts\select;
 
-class EnableCommand extends Command
+class EnableCommand extends AbstractCommand
 {
+    use InteractsWithExtensions;
+
     protected $signature = 'extension:enable {extension?}';
     protected $description = 'Enable the extension';
 
     public function handle(): void
     {
-        $name   = $this->argument('extension');
+        $name = $this->promptExtension('extensions::commands.select_extension_enable');
         if (! $name) {
-            $list = Extensions::all()->map(fn($e) => $e->getName())->toArray();
-            if ($this->input->isInteractive()) {
-                $name = $this->choice(trans('extensions::commands.select_extension_enable'), $list);
-            } else {
-                $this->error(trans('extensions::commands.extension_name_required'));
-                return;
-            }
+            return;
         }
         $result = Extensions::enable($name);
         $this->info($result);

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -2,27 +2,23 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use Gigabait93\Extensions\Commands\Concerns\InteractsWithExtensions;
+use function Laravel\Prompts\select;
 
-class InstallCommand extends Command
+class InstallCommand extends AbstractCommand
 {
+    use InteractsWithExtensions;
+
     protected $signature = 'extension:install {extension?} {--force}';
     protected $description = 'Set up a new extension (migrate + seed)';
 
     public function handle(): void
     {
-        $name = $this->argument('extension');
         $force = $this->option('force');
-
+        $name = $this->promptExtension('extensions::commands.select_extension_install');
         if (! $name) {
-            $list = Extensions::all()->map(fn($e) => $e->getName())->toArray();
-            if ($this->input->isInteractive()) {
-                $name = $this->choice(trans('extensions::commands.select_extension_install'), $list);
-            } else {
-                $this->error(trans('extensions::commands.extension_name_required'));
-                return;
-            }
+            return;
         }
 
         $result = Extensions::install($name, $force);

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -2,10 +2,10 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use function Laravel\Prompts\table;
 
-class ListCommand extends Command
+class ListCommand extends AbstractCommand
 {
     protected $signature   = 'extension:list';
     protected $description = 'Outputs a list of all extensions';
@@ -20,7 +20,7 @@ class ListCommand extends Command
             ];
         })->toArray();
 
-        $this->table([
+        table([
             trans('extensions::commands.table_name'),
             trans('extensions::commands.table_status'),
             trans('extensions::commands.table_type'),

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -2,10 +2,10 @@
 
 namespace Gigabait93\Extensions\Commands;
 
-use Illuminate\Console\Command;
 use Gigabait93\Extensions\Facades\Extensions;
+use function Laravel\Prompts\select;
 
-class MigrateCommand extends Command
+class MigrateCommand extends AbstractCommand
 {
     protected $signature   = 'extension:migrate
                             {name? : Extension name (default - all)}
@@ -24,7 +24,7 @@ class MigrateCommand extends Command
         } elseif ($this->input->isInteractive()) {
             $choices = $list->map(fn($e) => $e->getName())->toArray();
             $choices[] = trans('extensions::commands.option_all');
-            $choice = $this->choice(trans('extensions::commands.select_extension_migrate'), $choices);
+            $choice = select(trans('extensions::commands.select_extension_migrate'), $choices, $choices[0] ?? null);
             if ($choice !== trans('extensions::commands.option_all')) {
                 $list = $list->filter(fn($e) => $e->getName() === $choice);
             }

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -4,40 +4,21 @@ namespace Gigabait93\Extensions\Commands;
 
 use Gigabait93\Extensions\Actions\AddStubsAction;
 use Gigabait93\Extensions\Actions\GenerateStubsAction;
-use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
-use function Laravel\Prompts\{multiselect, select};
+use Gigabait93\Extensions\Commands\Concerns\HandlesStubs;
+use function Laravel\Prompts\select;
 
-class StubCommand extends Command
+class StubCommand extends AbstractCommand
 {
+    use HandlesStubs;
+
     protected $signature = 'extension:stub {name?} {path?} {--stub=* : Stub groups to generate}';
     protected $description = 'Generate additional stubs for an existing extension';
 
-    protected Filesystem $files;
-    protected array $bases;
-
-    public function __construct()
-    {
-        parent::__construct();
-        $this->files = new Filesystem;
-        $this->bases = config('extensions.paths', []);
-    }
-
     public function handle(): void
     {
-        if (empty($this->bases)) {
-            $this->error(trans('extensions::commands.paths_required'));
-            return;
-        }
-
-        $paths = array_values($this->bases);
-        $basePath = $this->argument('path');
-        if (! ($basePath && in_array($basePath, $paths, true))) {
-            $basePath = select(trans('extensions::commands.select_base_path'), $paths, $paths[0] ?? null);
-        }
+        $basePath = $this->selectBasePath($this->argument('path'));
         if (! $basePath) {
-            $this->error(trans('extensions::commands.base_path_required'));
             return;
         }
 
@@ -59,19 +40,7 @@ class StubCommand extends Command
 
         $stubRoot = config('extensions.stubs.path');
         $available = $this->availableStubs($stubRoot);
-        $stubs = $this->option('stub');
-        if (empty($stubs)) {
-            $optionAll = trans('extensions::commands.option_all');
-            $choices = array_merge([$optionAll], $available);
-            $default = array_values(array_diff(config('extensions.stubs.default') ?: $available, ['extension', 'providers']));
-            $stubs = multiselect(trans('extensions::commands.select_stubs'), $choices, $default);
-            if (in_array($optionAll, $stubs, true)) {
-                $stubs = $available;
-            }
-        }
-
-        $stubs = array_map('strtolower', $stubs);
-        $stubs = array_values(array_unique(array_merge($stubs, ['extension', 'providers'])));
+        $stubs = $this->resolveStubs($available);
 
         $generator = new GenerateStubsAction($this->files, $stubRoot);
         $action = new AddStubsAction($this->files, $generator);
@@ -84,19 +53,5 @@ class StubCommand extends Command
         }
 
         $this->info(trans('extensions::commands.stubs_generated'));
-    }
-
-    protected function availableStubs(string $stubRoot): array
-    {
-        $groups = [];
-        foreach ($this->files->allFiles($stubRoot) as $file) {
-            $rel = Str::after($file->getPathname(), $stubRoot . DIRECTORY_SEPARATOR);
-            $rel = str_replace('\\', '/', $rel);
-            $group = Str::before($rel, '/');
-            $group = Str::before($group, '.');
-            $groups[] = Str::lower($group);
-        }
-        $groups = array_values(array_unique($groups));
-        return array_values(array_diff($groups, ['extension', 'providers']));
     }
 }


### PR DESCRIPTION
## Summary
- add abstract command base and traits for stub and extension selection
- rewrite console commands to use Laravel Prompts helpers and shared logic
- remove repeated code for base path, stubs and extension name prompts

## Testing
- `php -l src/Commands/AbstractCommand.php`
- `php -l src/Commands/MakeCommand.php`
- `php -l src/Commands/InstallCommand.php`


------
https://chatgpt.com/codex/tasks/task_e_6894afec5ba883338570ad2d82eb705f