### PR TITLE
docs: add command usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,22 @@ Full documentation: [English](docs/en/introduction.md) | [Українська](
 | `extension:disable {extension}` | Disables a specific extension.                                            |
 | `extension:delete {extension}`  | Deletes a specific extension.                                             |
 | `extension:discover`            | Scans the extensions directory and synchronizes new extensions.           |
-| `extension:install {extension}` | Installs a specific extension.                                            |
-| `extension:meke {extension}`    | Interactive creation of a new extension (type based on path). |
+| `extension:install {extension}` | Installs a specific extension (migrate + seed).                           |
+| `extension:make {name}`         | Interactive creation of a new extension (type based on path).             |
+| `extension:stub {name}`         | Generates additional stubs for an existing extension.                     |
+| `extension:migrate {name?}`     | Runs migrations and seeders for extensions.                               |
+
+#### Command Usage Examples
+
+- `php artisan extension:list` – show all extensions.
+- `php artisan extension:enable Blog` – enable the "Blog" extension.
+- `php artisan extension:disable Blog` – disable the "Blog" extension.
+- `php artisan extension:delete Blog` – remove the "Blog" extension.
+- `php artisan extension:discover` – discover new extensions.
+- `php artisan extension:install Blog` – run migrations and seeds for "Blog".
+- `php artisan extension:make Blog modules` – scaffold a "Blog" extension in `modules`.
+- `php artisan extension:stub Blog modules` – generate stubs for the "Blog" extension.
+- `php artisan extension:migrate --force` – migrate all extensions without confirmation.
 
 ---
 

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -42,8 +42,22 @@ php artisan migrate
 | `extension:disable {extension}` | Disable a specific extension. |
 | `extension:delete {extension}` | Remove an extension from the system. |
 | `extension:discover` | Scan configured paths and synchronize new extensions. |
-| `extension:install {extension}` | Run installation routines for an extension. |
-| `extension:meke {extension}` | Interactively create a new extension. |
+| `extension:install {extension}` | Run installation routines for an extension (migrate + seed). |
+| `extension:make {name}` | Interactively create a new extension. |
+| `extension:stub {name}` | Generate additional stubs for an existing extension. |
+| `extension:migrate {name?}` | Run migrations and seeders for extensions. |
+
+## Command Usage Examples
+
+- `php artisan extension:list` – show all extensions.
+- `php artisan extension:enable Blog` – enable the "Blog" extension.
+- `php artisan extension:disable Blog` – disable the "Blog" extension.
+- `php artisan extension:delete Blog` – remove the "Blog" extension.
+- `php artisan extension:discover` – discover new extensions.
+- `php artisan extension:install Blog` – run migrations and seeds for "Blog".
+- `php artisan extension:make Blog modules` – scaffold a "Blog" extension in `modules`.
+- `php artisan extension:stub Blog modules` – generate stubs for the "Blog" extension.
+- `php artisan extension:migrate --force` – migrate all extensions without confirmation.
 
 ## Creating an Extension
 

--- a/docs/uk/usage.md
+++ b/docs/uk/usage.md
@@ -42,8 +42,22 @@ php artisan migrate
 | `extension:disable {extension}` | Вимикає конкретне розширення. |
 | `extension:delete {extension}` | Видаляє розширення з системи. |
 | `extension:discover` | Сканує шляхи та синхронізує нові розширення. |
-| `extension:install {extension}` | Запускає процедури встановлення розширення. |
-| `extension:meke {extension}` | Інтерактивно створює нове розширення. |
+| `extension:install {extension}` | Запускає процедури встановлення розширення (міграції та сідери). |
+| `extension:make {name}` | Інтерактивно створює нове розширення. |
+| `extension:stub {name}` | Генерує додаткові заготовки для наявного розширення. |
+| `extension:migrate {name?}` | Запускає міграції та сідери для розширень. |
+
+## Приклади використання команд
+
+- `php artisan extension:list` – показує всі розширення.
+- `php artisan extension:enable Blog` – вмикає розширення "Blog".
+- `php artisan extension:disable Blog` – вимикає розширення "Blog".
+- `php artisan extension:delete Blog` – видаляє розширення "Blog".
+- `php artisan extension:discover` – знаходить нові розширення.
+- `php artisan extension:install Blog` – запускає міграції та сідери для "Blog".
+- `php artisan extension:make Blog modules` – створює каркас розширення "Blog" у `modules`.
+- `php artisan extension:stub Blog modules` – генерує додаткові заготовки для "Blog".
+- `php artisan extension:migrate --force` – запускає міграції для всіх розширень без підтвердження.
 
 ## Створення розширення
 


### PR DESCRIPTION
## Summary
- document all available artisan extension commands
- add usage examples for common extension workflows

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_6894b4ff3ea883339dd0ab5ea95efa5f