### PR TITLE
Remove requires_packages from manifest documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,6 @@ extensions/
   "version": "1.0.0",
   "compatible_with": "^12.0",
   "requires_extensions": ["base"],
-  "requires_packages": {
-    "illuminate/support": "^12.0"
-  },
   "meta": {
     "category": "content"
   }

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -20,7 +20,6 @@ The following fields are supported:
 | `version` | no | Semantic version string. |
 | `compatible_with` | no | Target application version. |
 | `requires_extensions` | no | Array of extension IDs this one depends on. |
-| `requires_packages` | no | Map of Composer packages to version constraints. |
 | `meta` | no | Arbitrary JSON object for custom metadata. |
 
 Example `extension.json`:
@@ -36,9 +35,6 @@ Example `extension.json`:
   "version": "1.0.0",
   "compatible_with": "^12.0",
   "requires_extensions": ["base"],
-  "requires_packages": {
-    "illuminate/support": "^12.0"
-  },
   "meta": {
     "category": "content"
   }


### PR DESCRIPTION
- Remove requires_packages field from README.md example
- Remove requires_packages from docs/manifest.md documentation
- Dependencies should be managed via composer.json automatically
- Keeps documentation aligned with actual stub template